### PR TITLE
Fixes #177

### DIFF
--- a/Website/justHealthServer/api.py
+++ b/Website/justHealthServer/api.py
@@ -902,7 +902,7 @@ def getAllAppointments(loggedInUser, targetUser):
     appointment['androideventid'] = app.androideventid
     appointment['accepted'] = app.accepted
     
-    dateTime = str(app.startdate) + " " + str(app.starttime)
+    dateTime = str(app.enddate) + " " + str(app.endtime)
     dateTime = datetime.datetime.strptime(dateTime, "%Y-%m-%d %H:%M:%S")
 
     if (dateTime >= currentDateTime):

--- a/Website/justHealthServer/templates/dashboard.html
+++ b/Website/justHealthServer/templates/dashboard.html
@@ -396,7 +396,6 @@
                         {% if appointment.creator == session['username'] %}
                           {% if appointment.private == True %}
                             <p><em>This appointment is marked as private, your connections will not be able to see this. You can change this by updating your appointment.</em></p> <br />
-                            }
                           {% else %}
                             <br />
                           {% endif %}


### PR DESCRIPTION
This ensures that appointments  are displayed in upcoming/on the dashboard until the time that the end, not the time that they start. Fixes #177
